### PR TITLE
Add precisions about annotations autoloading

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -65,6 +65,12 @@ access the annotations of a class. A common one is
 
 .. code-block:: php
 
+    use Doctrine\Common\Annotations\AnnotationReader;
+    use Doctrine\Common\Annotations\AnnotationRegistry;
+    
+    // Deprecated and will be removed in 2.0 but currently needed
+    AnnotationRegistry::registerLoader('class_exists');
+    
     $reflectionClass = new ReflectionClass(Foo::class);
     $property = $reflectionClass->getProperty('bar');
 
@@ -75,6 +81,10 @@ access the annotations of a class. A common one is
     );
 
     echo $myAnnotation->myProperty; // result: "value"
+
+Note that ``AnnotationRegistry::registerLoader('class_exists')`` only works
+if you already have an autoloader configured (i.e. composer autoloader).
+Otherwise, :ref:`please take a look to the other annotation autoload mechanisms <annotations>`.
 
 A reader has multiple methods to access the annotations
 of a class.


### PR DESCRIPTION
The doc is not very clear about that register au autoloading mechanism is needed. When you just want to test a library, you most of the time just read the "getting started" page. And in that case the "getting started" page doesn't provide a working example because it doesn't talk about the autoloading system. This system is only explained in the more specific page "Handling annotations".

This PR aims to add a quick precision about that 🙂